### PR TITLE
test(integration): add test for orderBy and limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint '*/**/*.{js,ts}'",
     "lint:md": "remark README.md -o README.md",
     "prettier:check": "prettier --check 'src/**/*.{js,ts,jsx,tsx,json,css,scss,md}' 'docgen/build.ts' --loglevel warn",
-    "prettier:format": "prettier --write 'src/**/*.{js,ts,jsx,tsx,json,css,scss,md}' 'docgen/build.ts'",
+    "prettier:format": "prettier --write 'src/**/*.{js,ts,jsx,tsx,json,css,scss,md}' 'docgen/build.ts' 'test/**/*.{js,ts,jsx,tsx,json,css,scss,md}'",
     "release": "semantic-release",
     "test": "jest src --coverage=true",
     "test:integration": "jest -c test/jest.integration.js",

--- a/test/functional/9-queries.spec.ts
+++ b/test/functional/9-queries.spec.ts
@@ -1,44 +1,40 @@
-import { after } from "node:test";
-import { getRepository, Collection, BaseFirestoreRepository } from "../../src";
-import { Band as BandEntity, Website as Site } from "../fixture";
-import { getUniqueColName } from "../setup";
-import { url } from "node:inspector";
+import { getRepository, Collection, BaseFirestoreRepository } from '../../src';
+import { Band as BandEntity } from '../fixture';
+import { getUniqueColName } from '../setup';
 
-describe("Integration test: Queries", () => {
-
-  @Collection(getUniqueColName("band-queries-test"))
+describe('Integration test: Queries', () => {
+  @Collection(getUniqueColName('band-queries-test'))
   class Band extends BandEntity {}
 
   let bandRepository: BaseFirestoreRepository<Band>;
-
 
   beforeEach(async () => {
     // instantiate the repositories
     bandRepository = getRepository(Band);
 
     const ewf = new Band();
-    ewf.id = "earth-wind-and-fire";
-    ewf.name = "Earth, Wind & Fire";
+    ewf.id = 'earth-wind-and-fire';
+    ewf.name = 'Earth, Wind & Fire';
     ewf.formationYear = 1969;
-    ewf.genres = ["funk", "soul", "disco"];
+    ewf.genres = ['funk', 'soul', 'disco'];
 
     const pf = new Band();
-    pf.id = "parliament-funkadelic";
-    pf.name = "Parliament-Funkadelic";
+    pf.id = 'parliament-funkadelic';
+    pf.name = 'Parliament-Funkadelic';
     pf.formationYear = 1968;
-    pf.genres = ["funk", "soul"];
+    pf.genres = ['funk', 'soul'];
 
     const sfs = new Band();
-    sfs.id = "sly-and-the-family-stone";
-    sfs.name = "Sly and the Family Stone";
+    sfs.id = 'sly-and-the-family-stone';
+    sfs.name = 'Sly and the Family Stone';
     sfs.formationYear = 1966;
-    sfs.genres = ["funk", "soul", "psychedelic"];
+    sfs.genres = ['funk', 'soul', 'psychedelic'];
 
     const kg = new Band();
-    kg.id = "kool-and-the-gang";
-    kg.name = "Kool & The Gang";
+    kg.id = 'kool-and-the-gang';
+    kg.name = 'Kool & The Gang';
     kg.formationYear = 1964;
-    kg.genres = ["funk", "soul", "disco"];
+    kg.genres = ['funk', 'soul', 'disco'];
 
     await bandRepository.create(ewf);
     await bandRepository.create(pf);
@@ -51,67 +47,72 @@ describe("Integration test: Queries", () => {
     await Promise.all(allBands.map(band => bandRepository.delete(band.id)));
   });
 
-  describe("Simple Queries", () => {
-    test("should find a single band by id", async () => {
-      const parliament = await bandRepository.findById("parliament-funkadelic");
-      expect(parliament.id).toEqual("parliament-funkadelic");
+  describe('Simple Queries', () => {
+    test('should find a single band by id', async () => {
+      const parliament = await bandRepository.findById('parliament-funkadelic');
+      expect(parliament.id).toEqual('parliament-funkadelic');
       expect(parliament).not.toBeNull();
-      expect(parliament.name).toEqual("Parliament-Funkadelic");
+      expect(parliament.name).toEqual('Parliament-Funkadelic');
     });
 
-    test("should find all bands", async () => {
+    test('should find all bands', async () => {
       const allBands = await bandRepository.find();
       expect(allBands.length).toEqual(4);
     });
   });
 
-  describe("Filtering and Complex Queries", () => {
-    test("should filter bands by genre", async () => {
-      const funkBands = await bandRepository.whereArrayContains("genres", "funk").find();
+  describe('Filtering and Complex Queries', () => {
+    test('should filter bands by genre', async () => {
+      const funkBands = await bandRepository.whereArrayContains('genres', 'funk').find();
       expect(funkBands.length).toEqual(4);
 
-      const discoBands = await bandRepository.whereArrayContains("genres", "disco").find();
+      const discoBands = await bandRepository.whereArrayContains('genres', 'disco').find();
       expect(discoBands.length).toEqual(2);
 
-      const psychedelicBands = await bandRepository.whereArrayContains("genres", "psychedelic").find();
+      const psychedelicBands = await bandRepository
+        .whereArrayContains('genres', 'psychedelic')
+        .find();
       expect(psychedelicBands.length).toEqual(1);
     });
 
-    test("should filter bands by name", async () => {
-      const ewf = await bandRepository.whereEqualTo("name", "Earth, Wind & Fire").find();
+    test('should filter bands by name', async () => {
+      const ewf = await bandRepository.whereEqualTo('name', 'Earth, Wind & Fire').find();
       expect(ewf.length).toEqual(1);
-      expect(ewf.pop().id).toEqual("earth-wind-and-fire");
+      expect(ewf.pop().id).toEqual('earth-wind-and-fire');
     });
 
     // This test requires an index to be created in Firestore
     // Since each collection is unique, we can't create the index ahead of time
-    test.skip("should filter bands by formation year and genre", async () => {
+    test.skip('should filter bands by formation year and genre', async () => {
       const funkBefore67 = await bandRepository
-        .whereLessThan("formationYear", 1967)
-        .whereArrayContains("genres", "funk")
+        .whereLessThan('formationYear', 1967)
+        .whereArrayContains('genres', 'funk')
         .find();
 
       expect(funkBefore67.length).toEqual(2);
-      expect(funkBefore67.map(band => band.id)).toEqual(["sly-and-the-family-stone", "kool-and-the-gang"]);
+      expect(funkBefore67.map(band => band.id)).toEqual([
+        'sly-and-the-family-stone',
+        'kool-and-the-gang',
+      ]);
     });
   });
 
-  describe("orderBy and limit", () => {
-    test("should order bands by formation year ASC", async () => {
-      const bands = await bandRepository.orderByAscending("formationYear").find();
+  describe('orderBy and limit', () => {
+    test('should order bands by formation year ASC', async () => {
+      const bands = await bandRepository.orderByAscending('formationYear').find();
       expect(bands.length).toEqual(4);
-      expect(bands[0].id).toEqual("kool-and-the-gang");
-      expect(bands[3].id).toEqual("earth-wind-and-fire");
+      expect(bands[0].id).toEqual('kool-and-the-gang');
+      expect(bands[3].id).toEqual('earth-wind-and-fire');
     });
 
-    test("should order bands by formation year DESC", async () => {
-      const bands = await bandRepository.orderByDescending("formationYear").find();
+    test('should order bands by formation year DESC', async () => {
+      const bands = await bandRepository.orderByDescending('formationYear').find();
       expect(bands.length).toEqual(4);
-      expect(bands[0].id).toEqual("earth-wind-and-fire");
-      expect(bands[3].id).toEqual("kool-and-the-gang");
+      expect(bands[0].id).toEqual('earth-wind-and-fire');
+      expect(bands[3].id).toEqual('kool-and-the-gang');
     });
 
-    test("should limit the number of bands returned", async () => {
+    test('should limit the number of bands returned', async () => {
       const bands = await bandRepository.limit(2).find();
       expect(bands.length).toEqual(2);
 

--- a/test/functional/9-queries.spec.ts
+++ b/test/functional/9-queries.spec.ts
@@ -1,0 +1,122 @@
+import { after } from "node:test";
+import { getRepository, Collection, BaseFirestoreRepository } from "../../src";
+import { Band as BandEntity, Website as Site } from "../fixture";
+import { getUniqueColName } from "../setup";
+import { url } from "node:inspector";
+
+describe("Integration test: Queries", () => {
+
+  @Collection(getUniqueColName("band-queries-test"))
+  class Band extends BandEntity {}
+
+  let bandRepository: BaseFirestoreRepository<Band>;
+
+
+  beforeEach(async () => {
+    // instantiate the repositories
+    bandRepository = getRepository(Band);
+
+    const ewf = new Band();
+    ewf.id = "earth-wind-and-fire";
+    ewf.name = "Earth, Wind & Fire";
+    ewf.formationYear = 1969;
+    ewf.genres = ["funk", "soul", "disco"];
+
+    const pf = new Band();
+    pf.id = "parliament-funkadelic";
+    pf.name = "Parliament-Funkadelic";
+    pf.formationYear = 1968;
+    pf.genres = ["funk", "soul"];
+
+    const sfs = new Band();
+    sfs.id = "sly-and-the-family-stone";
+    sfs.name = "Sly and the Family Stone";
+    sfs.formationYear = 1966;
+    sfs.genres = ["funk", "soul", "psychedelic"];
+
+    const kg = new Band();
+    kg.id = "kool-and-the-gang";
+    kg.name = "Kool & The Gang";
+    kg.formationYear = 1964;
+    kg.genres = ["funk", "soul", "disco"];
+
+    await bandRepository.create(ewf);
+    await bandRepository.create(pf);
+    await bandRepository.create(sfs);
+    await bandRepository.create(kg);
+  });
+
+  afterEach(async () => {
+    const allBands = await bandRepository.find();
+    await Promise.all(allBands.map(band => bandRepository.delete(band.id)));
+  });
+
+  describe("Simple Queries", () => {
+    test("should find a single band by id", async () => {
+      const parliament = await bandRepository.findById("parliament-funkadelic");
+      expect(parliament.id).toEqual("parliament-funkadelic");
+      expect(parliament).not.toBeNull();
+      expect(parliament.name).toEqual("Parliament-Funkadelic");
+    });
+
+    test("should find all bands", async () => {
+      const allBands = await bandRepository.find();
+      expect(allBands.length).toEqual(4);
+    });
+  });
+
+  describe("Filtering and Complex Queries", () => {
+    test("should filter bands by genre", async () => {
+      const funkBands = await bandRepository.whereArrayContains("genres", "funk").find();
+      expect(funkBands.length).toEqual(4);
+
+      const discoBands = await bandRepository.whereArrayContains("genres", "disco").find();
+      expect(discoBands.length).toEqual(2);
+
+      const psychedelicBands = await bandRepository.whereArrayContains("genres", "psychedelic").find();
+      expect(psychedelicBands.length).toEqual(1);
+    });
+
+    test("should filter bands by name", async () => {
+      const ewf = await bandRepository.whereEqualTo("name", "Earth, Wind & Fire").find();
+      expect(ewf.length).toEqual(1);
+      expect(ewf.pop().id).toEqual("earth-wind-and-fire");
+    });
+
+    // This test requires an index to be created in Firestore
+    // Since each collection is unique, we can't create the index ahead of time
+    test.skip("should filter bands by formation year and genre", async () => {
+      const funkBefore67 = await bandRepository
+        .whereLessThan("formationYear", 1967)
+        .whereArrayContains("genres", "funk")
+        .find();
+
+      expect(funkBefore67.length).toEqual(2);
+      expect(funkBefore67.map(band => band.id)).toEqual(["sly-and-the-family-stone", "kool-and-the-gang"]);
+    });
+  });
+
+  describe("orderBy and limit", () => {
+    test("should order bands by formation year ASC", async () => {
+      const bands = await bandRepository.orderByAscending("formationYear").find();
+      expect(bands.length).toEqual(4);
+      expect(bands[0].id).toEqual("kool-and-the-gang");
+      expect(bands[3].id).toEqual("earth-wind-and-fire");
+    });
+
+    test("should order bands by formation year DESC", async () => {
+      const bands = await bandRepository.orderByDescending("formationYear").find();
+      expect(bands.length).toEqual(4);
+      expect(bands[0].id).toEqual("earth-wind-and-fire");
+      expect(bands[3].id).toEqual("kool-and-the-gang");
+    });
+
+    test("should limit the number of bands returned", async () => {
+      const bands = await bandRepository.limit(2).find();
+      expect(bands.length).toEqual(2);
+
+      const bands2 = await bandRepository.limit(3).find();
+      expect(bands2.length).toEqual(3);
+    });
+  });
+});


### PR DESCRIPTION
Issue #8 

- Add test coverage for query functions, filters and limiters
- Excluded test coverage for Document Reference queries, since that's covered well in `6-document-references.spec.ts`